### PR TITLE
Remove commented observability configuration from wrangler file

### DIFF
--- a/backend-domain-ms/wrangler.jsonc
+++ b/backend-domain-ms/wrangler.jsonc
@@ -16,9 +16,5 @@
 			"database_id": "d20b2855-46a5-4a1a-b964-90295000b794",
 			"remote": true
 		}
-	],
-	// "observability": {
-	//   "enabled": true,
-	//   "head_sampling_rate": 1
-	// }
+	]
 }


### PR DESCRIPTION
Eliminate unnecessary commented-out code related to observability in the wrangler configuration file.